### PR TITLE
Fix: Correct CryptoJS SRI integrity hash in base.html

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -58,7 +58,7 @@
         </div>
     </div>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.2.0/crypto-js.min.js" integrity="sha512-a+SUDuwNzXD5yt4JjnciHlvGJKyfJDyLTQMhLkA3dOKIpTAOi3LMrsi9Um99K9iKlagnextInt8nQZ2A/b9sLg2w==" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.2.0/crypto-js.min.js" integrity="sha512-a+SUDuwNzXDvz4XrIcXHuCf089/iJAoN4lmrXJg18XnduKK6YlDHNRalv4yd1N40OKI80tFidF+rqTFKGPoWFQ==" crossorigin="anonymous"></script>
     <script src="{{ url_for('static', filename='js/encryption.js') }}"></script>
     {% block extra_js %}{% endblock %}
 </body>


### PR DESCRIPTION
Updated the SHA-512 integrity hash in the `<script>` tag for the CryptoJS CDN link. The previous hash did not match the computed hash of the resource, causing browsers to block the script due to Subresource Integrity (SRI) failure.

This change ensures the CryptoJS library loads correctly, which is essential for the client-side encryption features.